### PR TITLE
DM-10779: Implement running time metric(s)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@
      :target: http://dx.doi.org/10.5281/zenodo.#####
 
 #############################
-Conventions Used by verify_ap
+Conventions Used by ap_verify
 #############################
 
 DMTN-054

--- a/index.rst
+++ b/index.rst
@@ -48,9 +48,26 @@
 
    **This technote is not yet published.**
 
-   Rules adopted by the AP pipeline to organize verification code throughout the Stack.
+The `LSST verify framework <https://github.com/lsst/verify>`_ involves the creation of Measurements throughout the Stack. These Measurements must be delivered to the `ap_verify framework <https://github.com/lsst-dm/ap_verify>`_ so that it can manage them and forward them to SQuaSH. We would like to integrate the ``verify`` code into the Stack in a way that minimizes the knowledge ``ap_verify`` must have of pipeline implementation details and maximizes the maintainability of the individual Tasks that will be instrumented. This document describes the conventions the ``ap_verify`` team has adopted to achieve both goals.
 
-.. Add content here.
+Metric definitions
+==================
+
+All AP verification metrics shall be stored in the `verify_metrics <https://github.com/lsst/verify_metrics>`_ package, following that package's conventions. Metrics and conventions for describing them are described on `Confluence <https://confluence.lsstcorp.org/display/~ebellm/Alert+Production+Metrics>`_; in particular, all our metrics should be tagged ``ap_verify`` for easy filtering and identification.
+
+Data Flow
+=========
+
+Each Task shall be responsible for the persistence of its own Measurements. As described in `SQR-019`_, this may be done by creating a Job object and attaching Measurements and Task-specific metadata, or through ``output_quantities``.
+
+Each Task must write its Measurements to disk in a location that will persist to at least the end of the pipeline run, and store the absolute path to the file in a metadata key named "<standard task prefix>.verify_json_path". ``ap_verify`` shall read any Measurement files mentioned in a Task's metadata, including files associated with subTasks.
+
+.. _SQR-019: https://sqr-019.lsst.io/
+
+Instrumenting Tasks
+===================
+
+TBD
 
 .. .. rubric:: References
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ serial_number: '054'
 doc_id: 'DMTN-054'
 
 # Title of the document, without the series/serial designation
-doc_title: 'Conventions Used by verify_ap'
+doc_title: 'Conventions Used by ap_verify'
 
 # Author names, ordered as a list. Each author name should be formatted as 'First Last'
 authors:


### PR DESCRIPTION
This PR summarizes assumptions made by this ticket's changes to `ap_verify`. The document as a whole is intended to be a reference for us as we continue to implement metrics.